### PR TITLE
프로필 이미지 URL 이 아닌 Base64 데이터 전달하도록 수정

### DIFF
--- a/user/profile.go
+++ b/user/profile.go
@@ -1,7 +1,9 @@
 package user
 
 import (
+	"encoding/base64"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 
@@ -29,9 +31,24 @@ func GetUserProfile(c *gin.Context) {
 		log.Fatal(err)
 	}
 	imgURL := consts.ForestURL + doc.Find("img#imgSajin").AttrOr("src", "")
+	imageData := "data:image/jpeg;base64,"
 	if imgURL == consts.ForestURL {
-		imgURL = ""
+		imageData = ""
+	} else {
+
+		client := &http.Client{}
+		req, _ := http.NewRequest("GET", imgURL, nil)
+		req.Header.Add("Cookie", c.MustGet("CredentialOld").(string))
+		res, err := client.Do(req)
+		if err != nil {
+			c.String(http.StatusInternalServerError, consts.InternalError)
+			return
+		}
+		defer res.Body.Close()
+		bytes, _ := ioutil.ReadAll(res.Body)
+		imageData += base64.StdEncoding.EncodeToString(bytes)
 	}
+
 	c.JSON(http.StatusOK, gin.H{
 		"name":       doc.Find("span#lblNm").Text(),
 		"id":         doc.Find("span#lblHagbeon").Text(),
@@ -42,6 +59,6 @@ func GetUserProfile(c *gin.Context) {
 		"classtype":  doc.Find("span#lblJuyaGbNm").Text(),
 		"coursetype": doc.Find("span#lblGwajeongGbNm").Text(),
 		"state":      doc.Find("span#lblHagjeogStGbNm").Text(),
-		"image":      imgURL,
+		"image":      imageData,
 	})
 }


### PR DESCRIPTION
종합정보시스템에서 jpeg 이미지를 text/html 형식으로 줘서 React Native 클라이언트에서 처리를 못함. 심지어 blob 으로 바꾼 후 datauri 변환하는것도 오류가 발생. 그래서 서버에서 처리 하는 것으로 대신함.