### PR TITLE
이벤트 중복 개선과 성능 개선

### DIFF
--- a/user/login.go
+++ b/user/login.go
@@ -137,6 +137,9 @@ func loginOnForest(ctx context.Context, loginData LoginData,
 
 	chromedp.ListenTarget(ctx, func(ev interface{}) {
 		go func() {
+			if _, ok := loginResult.Credentials["credential-old"]; ok {
+				return
+			}
 			if _, ok := ev.(*page.EventFrameStoppedLoading); ok {
 				targets, _ := chromedp.Targets(ctx)
 				if len(targets) == 0 {
@@ -195,6 +198,9 @@ func loginOnSam(ctx context.Context, loginData LoginData,
 	loginResult *LoginResult) {
 	chromedp.ListenTarget(ctx, func(ev interface{}) {
 		go func() {
+			if _, ok := loginResult.Credentials["credential-new"]; ok {
+				return
+			}
 			if _, ok := ev.(*page.EventFrameNavigated); ok {
 				targets, _ := chromedp.Targets(ctx)
 				if len(targets) == 0 {


### PR DESCRIPTION
이벤트 중복 때 인증정보를 덮어쓰고 WaitGroup 카운터를 사용해서 깨지는 현상을 막고 Sam - Forest 순으로 진행되던 로그인을 동시에 진행하게 변경