### PR TITLE
[hotfix/cors] nuttee 프론트엔드에서 접근허용

### DIFF
--- a/life/meal.go
+++ b/life/meal.go
@@ -12,6 +12,11 @@ import (
 	"github.com/s-owl/skhus-backend/tools"
 )
 
+func accessOther(c *gin.Context) {
+	c.Header("Access-Control-Allow-Headers", "Content-Type, Authorization, Origin")
+	c.Header("Acesss-Control-Allow-Origin", "*")
+}
+
 func GetMealURLs(c *gin.Context) {
 	targetURL := fmt.Sprintf("%s/uni_zelkova/uni_zelkova_4_3_list.aspx", consts.SkhuURL)
 
@@ -33,6 +38,7 @@ func GetMealURLs(c *gin.Context) {
 			"date":  item.Children().Eq(3).Text(),
 		})
 	})
+	accessOther(c)
 	c.JSON(http.StatusOK, gin.H{
 		"urls": mealUrls,
 	})
@@ -96,6 +102,7 @@ func GetMealData(c *gin.Context) {
 			},
 		})
 	}
+	accessOther(c)
 	c.JSON(http.StatusOK, gin.H{
 		"data": meal,
 	})


### PR DESCRIPTION
cors 헤더를 meal api에서만 전부 접근 허용으로 변경
nuttee 에서 작동하는지만 확인하면 됩니다.