### PR TITLE
[feature/cdp-cd] cloud run의 동시실행 설정 튜닝

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,7 +7,7 @@ steps:
     args: ['beta', 'run', 'deploy', 'skhus-backend-$BRANCH_NAME',
     '--image', 'asia.gcr.io/$PROJECT_ID/skhus-backend:$BRANCH_NAME',
     '--region', 'asia-northeast1',
-    '--memory', '512Mi',
-    '--concurrency=1',
+    '--memory', '1024Mi',
+    '--concurrency=2',
     '--platform', 'managed',
     '--allow-unauthenticated']


### PR DESCRIPTION
cloud-run 의 concurrency 옵션은 컨테이너 하나에 동시에 몇 개의
리퀘스트를 처리하게 설정하는 옵션이다. 이 옵션의 값을 초과한 요청이
들어오면 컨테이너 갯수를 스케일 업한다.

리퀘스트를 동시에 2개를 받으니 일단 램도 같이 업그레이드한다.