### PR TITLE
[hotfix/timeout] cloud-run 시간제한 설정 추가

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,5 +9,6 @@ steps:
     '--region', 'asia-northeast1',
     '--memory', '1024Mi',
     '--concurrency=2',
+    '--timeout=30s',
     '--platform', 'managed',
     '--allow-unauthenticated']


### PR DESCRIPTION
현재 실재 서버에서 실행시간이 3분을 자주 넘어서 클라우드 런에서 요청 시간 제한을
추가합니다.

30초로 설정합니다.